### PR TITLE
[Diagnostics] Add diagnostics of execution time and periodicity of the hardware components

### DIFF
--- a/controller_manager/doc/parameters_context.yaml
+++ b/controller_manager/doc/parameters_context.yaml
@@ -15,13 +15,13 @@ hardware_components_initial_state: |
             - "base3"
 
 diagnostics.threshold.controllers.periodicity: |
-  The ``periodicity`` diagnostics will be published only for the asynchronous controllers, because any affect to the synchronous controllers will be reflected directly in the controller manager's periodicity.
+  The ``periodicity`` diagnostics will be published for the asynchronous controllers, because any affect to the synchronous controllers will be reflected directly in the controller manager's periodicity. It is also published for the synchronous controllers that have a different update rate than the controller manager update rate.
 
 diagnostics.threshold.controllers.execution_time.mean_error: |
   The ``execution_time`` diagnostics will be published for all controllers. The ``mean_error`` for a synchronous controller will be computed against zero, as it should be as low as possible. However, the ``mean_error`` for an asynchronous controller will be computed against the controller's desired update period, as the controller can take a maximum of the desired period to execute its update cycle.
 
 diagnostics.threshold.hardware_components.periodicity: |
-  The ``periodicity`` diagnostics will be published only for the asynchronous hardware components, because any affect to the synchronous hardware components will be reflected directly in the controller manager's periodicity.
+  The ``periodicity`` diagnostics will be published for the asynchronous hardware components, because any affect to the synchronous hardware components will be reflected directly in the controller manager's periodicity. It is also published for the synchronous hardware components that have a different read/write rate than the controller manager update rate.
 
 diagnostics.threshold.hardware_components.execution_time.mean_error: |
   The ``execution_time`` diagnostics will be published for all hardware components. The ``mean_error`` for a synchronous hardware component will be computed against zero, as it should be as low as possible. However, the ``mean_error`` for an asynchronous hardware component will be computed against its desired read/write period, as the hardware component can take a maximum of the desired period to execute the read/write cycle.

--- a/controller_manager/doc/parameters_context.yaml
+++ b/controller_manager/doc/parameters_context.yaml
@@ -17,5 +17,11 @@ hardware_components_initial_state: |
 diagnostics.threshold.controllers.periodicity: |
   The ``periodicity`` diagnostics will be published only for the asynchronous controllers, because any affect to the synchronous controllers will be reflected directly in the controller manager's periodicity.
 
-diagnostics.threshold.controllers.execution_time: |
-  The ``execution_time`` diagnostics will be published for all controllers. The ``mean_error`` for a synchronous controller will be computed against zero, as it should be as low as possible. However, the ``mean_error`` for an asynchronous controller will be computed against the controller's desired update period, as the controller can take a maximum of the desired period cycle to execute it's update cycle.
+diagnostics.threshold.controllers.execution_time.mean_error: |
+  The ``execution_time`` diagnostics will be published for all controllers. The ``mean_error`` for a synchronous controller will be computed against zero, as it should be as low as possible. However, the ``mean_error`` for an asynchronous controller will be computed against the controller's desired update period, as the controller can take a maximum of the desired period to execute its update cycle.
+
+diagnostics.threshold.hardware_components.periodicity: |
+  The ``periodicity`` diagnostics will be published only for the asynchronous hardware components, because any affect to the synchronous hardware components will be reflected directly in the controller manager's periodicity.
+
+diagnostics.threshold.hardware_components.execution_time.mean_error: |
+  The ``execution_time`` diagnostics will be published for all hardware components. The ``mean_error`` for a synchronous hardware component will be computed against zero, as it should be as low as possible. However, the ``mean_error`` for an asynchronous hardware component will be computed against its desired read/write period, as the hardware component can take a maximum of the desired period to execute the read/write cycle.

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -3388,12 +3388,21 @@ void ControllerManager::controller_activity_diagnostic_callback(
 void ControllerManager::hardware_components_diagnostic_callback(
   diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
+  if (!is_resource_manager_initialized())
+  {
+    stat.summary(
+      diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Resource manager is not yet initialized!");
+    return;
+  }
+
   bool all_active = true;
   bool atleast_one_hw_active = false;
+  const std::string read_cycle_suffix = ".read_cycle";
+  const std::string write_cycle_suffix = ".write_cycle";
+  const std::string state_suffix = ".state";
   const auto & hw_components_info = resource_manager_->get_components_status();
   for (const auto & [component_name, component_info] : hw_components_info)
   {
-    stat.add(component_name, component_info.state.label());
     if (component_info.state.id() != lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
     {
       all_active = false;
@@ -3403,31 +3412,165 @@ void ControllerManager::hardware_components_diagnostic_callback(
       atleast_one_hw_active = true;
     }
   }
-  if (!is_resource_manager_initialized())
-  {
-    stat.summary(
-      diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Resource manager is not yet initialized!");
-  }
-  else if (hw_components_info.empty())
+  if (hw_components_info.empty())
   {
     stat.summary(
       diagnostic_msgs::msg::DiagnosticStatus::ERROR, "No hardware components are loaded!");
+    return;
   }
-  else
+  else if (!atleast_one_hw_active)
   {
-    if (!atleast_one_hw_active)
+    stat.summary(
+      diagnostic_msgs::msg::DiagnosticStatus::WARN, "No hardware components are currently active");
+    return;
+  }
+
+  stat.summary(
+    diagnostic_msgs::msg::DiagnosticStatus::OK,
+    all_active ? "All hardware components are active" : "Not all hardware components are active");
+
+  if (cm_param_listener_->is_old(*params_))
+  {
+    *params_ = cm_param_listener_->get_params();
+  }
+
+  auto make_stats_string =
+    [](const auto & statistics_data, const std::string & measurement_unit) -> std::string
+  {
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(2);
+    oss << "Avg: " << statistics_data.average << " [" << statistics_data.min << " - "
+        << statistics_data.max << "] " << measurement_unit
+        << ", StdDev: " << statistics_data.standard_deviation;
+    return oss.str();
+  };
+
+  // Variable to define the overall status of the controller diagnostics
+  auto level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+
+  std::vector<std::string> high_exec_time_hw;
+  std::vector<std::string> bad_periodicity_async_hw;
+
+  for (const auto & [component_name, component_info] : hw_components_info)
+  {
+    stat.add(component_name + state_suffix, component_info.state.label());
+    if (component_info.state.id() != lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
     {
-      stat.summary(
-        diagnostic_msgs::msg::DiagnosticStatus::WARN,
-        "No hardware components are currently active");
+      all_active = false;
     }
     else
     {
-      stat.summary(
-        diagnostic_msgs::msg::DiagnosticStatus::OK, all_active
-                                                      ? "All hardware components are active"
-                                                      : "Not all hardware components are active");
+      atleast_one_hw_active = true;
     }
+    if (component_info.state.id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
+    {
+      auto update_stats =
+        [&bad_periodicity_async_hw, &high_exec_time_hw, &stat, &make_stats_string](
+          const std::string & comp_name, const auto & statistics,
+          const std::string & statistics_type_suffix, auto & diag_level, const auto & comp_info,
+          const auto & params)
+      {
+        if (!statistics)
+        {
+          return;
+        }
+        const bool is_async = comp_info.is_async;
+        const std::string periodicity_suffix = ".periodicity";
+        const std::string exec_time_suffix = ".execution_time";
+        const auto periodicity_stats = statistics->periodicity.get_statistics();
+        const auto exec_time_stats = statistics->execution_time.get_statistics();
+        stat.add(
+          comp_name + statistics_type_suffix + exec_time_suffix,
+          make_stats_string(exec_time_stats, "us"));
+        if (is_async)
+        {
+          stat.add(
+            comp_name + statistics_type_suffix + periodicity_suffix,
+            make_stats_string(periodicity_stats, "Hz") +
+              " -> Desired : " + std::to_string(comp_info.rw_rate) + " Hz");
+          const double periodicity_error =
+            std::abs(periodicity_stats.average - static_cast<double>(comp_info.rw_rate));
+          if (
+            periodicity_error >
+              params->diagnostics.threshold.hardware_components.periodicity.mean_error.error ||
+            periodicity_stats.standard_deviation > params->diagnostics.threshold.hardware_components
+                                                     .periodicity.standard_deviation.error)
+          {
+            diag_level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+            add_element_to_list(bad_periodicity_async_hw, comp_name);
+          }
+          else if (
+            periodicity_error >
+              params->diagnostics.threshold.hardware_components.periodicity.mean_error.warn ||
+            periodicity_stats.standard_deviation >
+              params->diagnostics.threshold.hardware_components.periodicity.standard_deviation.warn)
+          {
+            if (diag_level != diagnostic_msgs::msg::DiagnosticStatus::ERROR)
+            {
+              diag_level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+            }
+            add_element_to_list(bad_periodicity_async_hw, comp_name);
+          }
+        }
+        const double max_exp_exec_time =
+          is_async ? 1.e6 / static_cast<double>(comp_info.rw_rate) : 0.0;
+        if (
+          (exec_time_stats.average - max_exp_exec_time) >
+            params->diagnostics.threshold.hardware_components.execution_time.mean_error.error ||
+          exec_time_stats.standard_deviation > params->diagnostics.threshold.hardware_components
+                                                 .execution_time.standard_deviation.error)
+        {
+          diag_level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+          high_exec_time_hw.push_back(comp_name);
+        }
+        else if (
+          (exec_time_stats.average - max_exp_exec_time) >
+            params->diagnostics.threshold.hardware_components.execution_time.mean_error.warn ||
+          exec_time_stats.standard_deviation > params->diagnostics.threshold.hardware_components
+                                                 .execution_time.standard_deviation.warn)
+        {
+          if (diag_level != diagnostic_msgs::msg::DiagnosticStatus::ERROR)
+          {
+            diag_level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+          }
+          high_exec_time_hw.push_back(comp_name);
+        }
+      };
+
+      // For components : {actuator, sensor and system}
+      update_stats(
+        component_name, component_info.read_statistics, read_cycle_suffix, level, component_info,
+        params_);
+      // For components : {actuator and system}
+      update_stats(
+        component_name, component_info.write_statistics, write_cycle_suffix, level, component_info,
+        params_);
+    }
+  }
+
+  if (!high_exec_time_hw.empty())
+  {
+    std::string high_exec_time_hw_string;
+    for (const auto & hw_comp : high_exec_time_hw)
+    {
+      high_exec_time_hw_string.append(hw_comp);
+      high_exec_time_hw_string.append(" ");
+    }
+    stat.mergeSummary(
+      level,
+      "\nHardware Components with high execution time : [ " + high_exec_time_hw_string + "]");
+  }
+  if (!bad_periodicity_async_hw.empty())
+  {
+    std::string bad_periodicity_async_hw_string;
+    for (const auto & hw_comp : bad_periodicity_async_hw)
+    {
+      bad_periodicity_async_hw_string.append(hw_comp);
+      bad_periodicity_async_hw_string.append(" ");
+    }
+    stat.mergeSummary(
+      level,
+      "\nHardware Components with bad periodicity : [ " + bad_periodicity_async_hw_string + "]");
   }
 }
 

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -3288,7 +3288,9 @@ void ControllerManager::controller_activity_diagnostic_callback(
       const auto exec_time_stats = controllers[i].execution_time_statistics->GetStatistics();
       stat.add(
         controllers[i].info.name + exec_time_suffix, make_stats_string(exec_time_stats, "us"));
-      if (is_async)
+      const bool publish_periodicity_stats =
+        is_async || (controllers[i].c->get_update_rate() != this->get_update_rate());
+      if (publish_periodicity_stats)
       {
         stat.add(
           controllers[i].info.name + periodicity_suffix,
@@ -3482,7 +3484,9 @@ void ControllerManager::hardware_components_diagnostic_callback(
         stat.add(
           comp_name + statistics_type_suffix + exec_time_suffix,
           make_stats_string(exec_time_stats, "us"));
-        if (is_async)
+        const bool publish_periodicity_stats =
+          is_async || (controllers[i].c->get_update_rate() != this->get_update_rate());
+        if (publish_periodicity_stats)
         {
           stat.add(
             comp_name + statistics_type_suffix + periodicity_suffix,

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -3561,8 +3561,7 @@ void ControllerManager::hardware_components_diagnostic_callback(
       high_exec_time_hw_string.append(" ");
     }
     stat.mergeSummary(
-      level,
-      "\nHardware Components with high execution time : [ " + high_exec_time_hw_string + "]");
+      level, "\nHigh execution jitter or mean error : [ " + high_exec_time_hw_string + "]");
   }
   if (!bad_periodicity_async_hw.empty())
   {
@@ -3574,7 +3573,7 @@ void ControllerManager::hardware_components_diagnostic_callback(
     }
     stat.mergeSummary(
       level,
-      "\nHardware Components with bad periodicity : [ " + bad_periodicity_async_hw_string + "]");
+      "\nHigh periodicity jitter or mean error : [ " + bad_periodicity_async_hw_string + "]");
   }
 }
 

--- a/controller_manager/src/controller_manager_parameters.yaml
+++ b/controller_manager/src/controller_manager_parameters.yaml
@@ -134,3 +134,74 @@ controller_manager:
                 gt<>: 0.0,
               }
             }
+      hardware_components:
+        periodicity:
+          mean_error:
+            warn: {
+              type: double,
+              default_value: 5.0,
+              description: "The warning threshold for the mean error of the hardware component's read/write loop. If the mean error exceeds this threshold, a warning diagnostic will be published.",
+              validation: {
+                gt<>: 0.0,
+              }
+            }
+            error: {
+              type: double,
+              default_value: 10.0,
+              description: "The error threshold for the mean error of the hardware component's read/write loop. If the mean error exceeds this threshold, an error diagnostic will be published.",
+              validation: {
+                gt<>: 0.0,
+              }
+            }
+          standard_deviation:
+            warn: {
+              type: double,
+              default_value: 5.0,
+              description: "The warning threshold for the standard deviation of the hardware component's read/write loop. If the standard deviation exceeds this threshold, a warning diagnostic will be published.",
+              validation: {
+                gt<>: 0.0,
+              }
+            }
+            error: {
+              type: double,
+              default_value: 10.0,
+              description: "The error threshold for the standard deviation of the hardware component's read/write loop. If the standard deviation exceeds this threshold, an error diagnostic will be published.",
+              validation: {
+                gt<>: 0.0,
+              }
+            }
+        execution_time:
+          mean_error:
+            warn: {
+              type: double,
+              default_value: 1000.0,
+              description: "The warning threshold for the mean error of the hardware component's read/write cycle execution time in microseconds. If the mean error exceeds this threshold, a warning diagnostic will be published.",
+              validation: {
+                gt<>: 0.0,
+              }
+            }
+            error: {
+              type: double,
+              default_value: 2000.0,
+              description: "The error threshold for the mean error of the hardware component's read/write cycle execution time in microseconds. If the mean error exceeds this threshold, a error diagnostic will be published.",
+              validation: {
+                gt<>: 0.0,
+              }
+            }
+          standard_deviation:
+            warn: {
+              type: double,
+              default_value: 100.0,
+              description: "The warning threshold for the standard deviation of the hardware component's read/write cycle execution time. If the standard deviation exceeds this threshold, a warning diagnostic will be published.",
+              validation: {
+                gt<>: 0.0,
+              }
+            }
+            error: {
+              type: double,
+              default_value: 200.0,
+              description: "The error threshold for the standard deviation of the hardware component's update cycle execution time. If the standard deviation exceeds this threshold, an error diagnostic will be published.",
+              validation: {
+                gt<>: 0.0,
+              }
+            }

--- a/controller_manager/src/controller_manager_parameters.yaml
+++ b/controller_manager/src/controller_manager_parameters.yaml
@@ -140,7 +140,7 @@ controller_manager:
             warn: {
               type: double,
               default_value: 5.0,
-              description: "The warning threshold for the mean error of the hardware component's read/write loop. If the mean error exceeds this threshold, a warning diagnostic will be published.",
+              description: "The warning threshold for the mean error of the hardware component's read/write loop in Hz. If the mean error exceeds this threshold, a warning diagnostic will be published.",
               validation: {
                 gt<>: 0.0,
               }
@@ -148,7 +148,7 @@ controller_manager:
             error: {
               type: double,
               default_value: 10.0,
-              description: "The error threshold for the mean error of the hardware component's read/write loop. If the mean error exceeds this threshold, an error diagnostic will be published.",
+              description: "The error threshold for the mean error of the hardware component's read/write loop in Hz. If the mean error exceeds this threshold, an error diagnostic will be published.",
               validation: {
                 gt<>: 0.0,
               }
@@ -157,7 +157,7 @@ controller_manager:
             warn: {
               type: double,
               default_value: 5.0,
-              description: "The warning threshold for the standard deviation of the hardware component's read/write loop. If the standard deviation exceeds this threshold, a warning diagnostic will be published.",
+              description: "The warning threshold for the standard deviation of the hardware component's read/write loop in Hz. If the standard deviation exceeds this threshold, a warning diagnostic will be published.",
               validation: {
                 gt<>: 0.0,
               }
@@ -165,7 +165,7 @@ controller_manager:
             error: {
               type: double,
               default_value: 10.0,
-              description: "The error threshold for the standard deviation of the hardware component's read/write loop. If the standard deviation exceeds this threshold, an error diagnostic will be published.",
+              description: "The error threshold for the standard deviation of the hardware component's read/write loop in Hz. If the standard deviation exceeds this threshold, an error diagnostic will be published.",
               validation: {
                 gt<>: 0.0,
               }
@@ -192,7 +192,7 @@ controller_manager:
             warn: {
               type: double,
               default_value: 100.0,
-              description: "The warning threshold for the standard deviation of the hardware component's read/write cycle execution time. If the standard deviation exceeds this threshold, a warning diagnostic will be published.",
+              description: "The warning threshold for the standard deviation of the hardware component's read/write cycle execution time in microseconds. If the standard deviation exceeds this threshold, a warning diagnostic will be published.",
               validation: {
                 gt<>: 0.0,
               }
@@ -200,7 +200,7 @@ controller_manager:
             error: {
               type: double,
               default_value: 200.0,
-              description: "The error threshold for the standard deviation of the hardware component's update cycle execution time. If the standard deviation exceeds this threshold, an error diagnostic will be published.",
+              description: "The error threshold for the standard deviation of the hardware component's update cycle execution time in microseconds. If the standard deviation exceeds this threshold, an error diagnostic will be published.",
               validation: {
                 gt<>: 0.0,
               }

--- a/hardware_interface/include/hardware_interface/actuator.hpp
+++ b/hardware_interface/include/hardware_interface/actuator.hpp
@@ -23,6 +23,7 @@
 #include "hardware_interface/handle.hpp"
 #include "hardware_interface/hardware_info.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include "hardware_interface/types/statistics_types.hpp"
 #include "rclcpp/duration.hpp"
 #include "rclcpp/logger.hpp"
 #include "rclcpp/node_interfaces/node_clock_interface.hpp"
@@ -82,6 +83,10 @@ public:
 
   const rclcpp::Time & get_last_write_time() const;
 
+  const HardwareComponentStatisticsCollector & get_read_statistics() const;
+
+  const HardwareComponentStatisticsCollector & get_write_statistics() const;
+
   return_type read(const rclcpp::Time & time, const rclcpp::Duration & period);
 
   return_type write(const rclcpp::Time & time, const rclcpp::Duration & period);
@@ -95,6 +100,9 @@ private:
   rclcpp::Time last_read_cycle_time_;
   // Last write cycle time
   rclcpp::Time last_write_cycle_time_;
+  // Component statistics
+  HardwareComponentStatisticsCollector read_statistics_;
+  HardwareComponentStatisticsCollector write_statistics_;
 };
 
 }  // namespace hardware_interface

--- a/hardware_interface/include/hardware_interface/hardware_component_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_component_info.hpp
@@ -19,14 +19,21 @@
 #ifndef HARDWARE_INTERFACE__HARDWARE_COMPONENT_INFO_HPP_
 #define HARDWARE_INTERFACE__HARDWARE_COMPONENT_INFO_HPP_
 
+#include <memory>
 #include <string>
 #include <vector>
 
-#include <rclcpp/time.hpp>
+#include "rclcpp/time.hpp"
 #include "rclcpp_lifecycle/state.hpp"
 
+#include "hardware_interface/types/statistics_types.hpp"
 namespace hardware_interface
 {
+struct HardwareComponentStatisticsData
+{
+  ros2_control::MovingAverageStatisticsData execution_time;
+  ros2_control::MovingAverageStatisticsData periodicity;
+};
 /// Hardware Component Information
 /**
  * This struct contains information about a given hardware component.
@@ -59,6 +66,12 @@ struct HardwareComponentInfo
 
   /// List of provided command interfaces by the component.
   std::vector<std::string> command_interfaces;
+
+  /// Read cycle statistics of the component.
+  std::shared_ptr<HardwareComponentStatisticsData> read_statistics = nullptr;
+
+  /// Write cycle statistics of the component.
+  std::shared_ptr<HardwareComponentStatisticsData> write_statistics = nullptr;
 };
 
 }  // namespace hardware_interface

--- a/hardware_interface/include/hardware_interface/sensor.hpp
+++ b/hardware_interface/include/hardware_interface/sensor.hpp
@@ -23,6 +23,7 @@
 #include "hardware_interface/hardware_info.hpp"
 #include "hardware_interface/sensor_interface.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include "hardware_interface/types/statistics_types.hpp"
 #include "rclcpp/duration.hpp"
 #include "rclcpp/logger.hpp"
 #include "rclcpp/node_interfaces/node_clock_interface.hpp"
@@ -70,6 +71,8 @@ public:
 
   const rclcpp::Time & get_last_read_time() const;
 
+  const HardwareComponentStatisticsCollector & get_read_statistics() const;
+
   return_type read(const rclcpp::Time & time, const rclcpp::Duration & period);
 
   return_type write(const rclcpp::Time &, const rclcpp::Duration &) { return return_type::OK; }
@@ -81,6 +84,8 @@ private:
   mutable std::recursive_mutex sensors_mutex_;
   // Last read cycle time
   rclcpp::Time last_read_cycle_time_;
+  // Component statistics
+  HardwareComponentStatisticsCollector read_statistics_;
 };
 
 }  // namespace hardware_interface

--- a/hardware_interface/include/hardware_interface/system.hpp
+++ b/hardware_interface/include/hardware_interface/system.hpp
@@ -23,6 +23,7 @@
 #include "hardware_interface/hardware_info.hpp"
 #include "hardware_interface/system_interface.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include "hardware_interface/types/statistics_types.hpp"
 #include "rclcpp/duration.hpp"
 #include "rclcpp/logger.hpp"
 #include "rclcpp/node_interfaces/node_clock_interface.hpp"
@@ -82,6 +83,10 @@ public:
 
   const rclcpp::Time & get_last_write_time() const;
 
+  const HardwareComponentStatisticsCollector & get_read_statistics() const;
+
+  const HardwareComponentStatisticsCollector & get_write_statistics() const;
+
   return_type read(const rclcpp::Time & time, const rclcpp::Duration & period);
 
   return_type write(const rclcpp::Time & time, const rclcpp::Duration & period);
@@ -95,6 +100,9 @@ private:
   rclcpp::Time last_read_cycle_time_;
   // Last write cycle time
   rclcpp::Time last_write_cycle_time_;
+  // Component statistics
+  HardwareComponentStatisticsCollector read_statistics_;
+  HardwareComponentStatisticsCollector write_statistics_;
 };
 
 }  // namespace hardware_interface

--- a/hardware_interface/include/hardware_interface/types/statistics_types.hpp
+++ b/hardware_interface/include/hardware_interface/types/statistics_types.hpp
@@ -1,0 +1,141 @@
+// Copyright 2025 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// \author Sai Kishor Kothakota
+
+#ifndef HARDWARE_INTERFACE__TYPES__STATISTICS_TYPES_HPP_
+#define HARDWARE_INTERFACE__TYPES__STATISTICS_TYPES_HPP_
+
+#include <limits>
+#include <memory>
+
+#include "libstatistics_collector/moving_average_statistics/moving_average.hpp"
+#include "libstatistics_collector/moving_average_statistics/types.hpp"
+#include "realtime_tools/mutex.hpp"
+
+namespace ros2_control
+{
+/**
+ * @brief Data structure to store the statistics of a moving average. The data is protected by a
+ * mutex and the data can be updated and retrieved.
+ */
+class MovingAverageStatisticsData
+{
+  using MovingAverageStatisticsCollector =
+    libstatistics_collector::moving_average_statistics::MovingAverageStatistics;
+  using StatisticData = libstatistics_collector::moving_average_statistics::StatisticData;
+
+public:
+  MovingAverageStatisticsData()
+  {
+    reset();
+    reset_statistics_sample_count_ = std::numeric_limits<unsigned int>::max();
+  }
+
+  /**
+   * @brief Update the statistics data with the new statistics data.
+   * @param statistics statistics collector to update the current statistics data.
+   */
+  void update_statistics(const std::shared_ptr<MovingAverageStatisticsCollector> & statistics)
+  {
+    std::unique_lock<realtime_tools::prio_inherit_mutex> lock(mutex_);
+    if (statistics->GetCount() > 0)
+    {
+      statistics_data.average = statistics->Average();
+      statistics_data.min = statistics->Min();
+      statistics_data.max = statistics->Max();
+      statistics_data.standard_deviation = statistics->StandardDeviation();
+      statistics_data.sample_count = statistics->GetCount();
+      statistics_data = statistics->GetStatistics();
+    }
+    if (statistics->GetCount() >= reset_statistics_sample_count_)
+    {
+      statistics->Reset();
+    }
+  }
+
+  /**
+   * @brief Set the number of samples to reset the statistics.
+   * @param reset_sample_count number of samples to reset the statistics.
+   */
+  void set_reset_statistics_sample_count(unsigned int reset_sample_count)
+  {
+    std::unique_lock<realtime_tools::prio_inherit_mutex> lock(mutex_);
+    reset_statistics_sample_count_ = reset_sample_count;
+  }
+
+  void reset()
+  {
+    statistics_data.average = std::numeric_limits<double>::quiet_NaN();
+    statistics_data.min = std::numeric_limits<double>::quiet_NaN();
+    statistics_data.max = std::numeric_limits<double>::quiet_NaN();
+    statistics_data.standard_deviation = std::numeric_limits<double>::quiet_NaN();
+    statistics_data.sample_count = 0;
+  }
+
+  /**
+   * @brief Get the statistics data.
+   * @return statistics data.
+   */
+  const StatisticData & get_statistics() const
+  {
+    std::unique_lock<realtime_tools::prio_inherit_mutex> lock(mutex_);
+    return statistics_data;
+  }
+
+private:
+  /// Statistics data
+  StatisticData statistics_data;
+  /// Number of samples to reset the statistics
+  unsigned int reset_statistics_sample_count_ = std::numeric_limits<unsigned int>::max();
+  /// Mutex to protect the statistics data
+  mutable realtime_tools::prio_inherit_mutex mutex_;
+};
+}  // namespace ros2_control
+
+namespace hardware_interface
+{
+/**
+ * @brief Data structure with two moving average statistics collectors. One for the execution time
+ * and the other for the periodicity.
+ */
+struct HardwareComponentStatisticsCollector
+{
+  HardwareComponentStatisticsCollector()
+  {
+    execution_time = std::make_shared<MovingAverageStatisticsCollector>();
+    periodicity = std::make_shared<MovingAverageStatisticsCollector>();
+  }
+
+  using MovingAverageStatisticsCollector =
+    libstatistics_collector::moving_average_statistics::MovingAverageStatistics;
+
+  /**
+   * @brief Resets the internal statistics of the execution time and periodicity statistics
+   * collectors.
+   */
+  void reset_statistics()
+  {
+    execution_time->Reset();
+    periodicity->Reset();
+  }
+
+  /// Execution time statistics collector
+  std::shared_ptr<MovingAverageStatisticsCollector> execution_time = nullptr;
+  /// Periodicity statistics collector
+  std::shared_ptr<MovingAverageStatisticsCollector> periodicity = nullptr;
+};
+}  // namespace hardware_interface
+
+#endif  // HARDWARE_INTERFACE__TYPES__STATISTICS_TYPES_HPP_

--- a/hardware_interface/src/sensor.cpp
+++ b/hardware_interface/src/sensor.cpp
@@ -140,6 +140,7 @@ const rclcpp_lifecycle::State & Sensor::activate()
 {
   std::unique_lock<std::recursive_mutex> lock(sensors_mutex_);
   last_read_cycle_time_ = rclcpp::Time(0, 0, RCL_CLOCK_UNINITIALIZED);
+  read_statistics_.reset_statistics();
   if (impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
   {
     switch (impl_->on_activate(impl_->get_lifecycle_state()))
@@ -249,6 +250,11 @@ const rclcpp_lifecycle::State & Sensor::get_lifecycle_state() const
 
 const rclcpp::Time & Sensor::get_last_read_time() const { return last_read_cycle_time_; }
 
+const HardwareComponentStatisticsCollector & Sensor::get_read_statistics() const
+{
+  return read_statistics_;
+}
+
 return_type Sensor::read(const rclcpp::Time & time, const rclcpp::Duration & period)
 {
   if (lifecycleStateThatRequiresNoAction(impl_->get_lifecycle_state().id()))
@@ -265,7 +271,20 @@ return_type Sensor::read(const rclcpp::Time & time, const rclcpp::Duration & per
     {
       error();
     }
-    last_read_cycle_time_ = time;
+    if (trigger_result.successful)
+    {
+      if (trigger_result.execution_time.has_value())
+      {
+        read_statistics_.execution_time->AddMeasurement(
+          static_cast<double>(trigger_result.execution_time.value().count()) / 1.e3);
+      }
+      if (last_read_cycle_time_.get_clock_type() != RCL_CLOCK_UNINITIALIZED)
+      {
+        read_statistics_.periodicity->AddMeasurement(
+          1.0 / (time - last_read_cycle_time_).seconds());
+      }
+      last_read_cycle_time_ = time;
+    }
     return trigger_result.result;
   }
   return return_type::OK;

--- a/hardware_interface/src/system.cpp
+++ b/hardware_interface/src/system.cpp
@@ -141,6 +141,8 @@ const rclcpp_lifecycle::State & System::activate()
   std::unique_lock<std::recursive_mutex> lock(system_mutex_);
   last_read_cycle_time_ = rclcpp::Time(0, 0, RCL_CLOCK_UNINITIALIZED);
   last_write_cycle_time_ = rclcpp::Time(0, 0, RCL_CLOCK_UNINITIALIZED);
+  read_statistics_.reset_statistics();
+  write_statistics_.reset_statistics();
   if (impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
   {
     impl_->prepare_for_activation();
@@ -294,6 +296,16 @@ const rclcpp::Time & System::get_last_read_time() const { return last_read_cycle
 
 const rclcpp::Time & System::get_last_write_time() const { return last_write_cycle_time_; }
 
+const HardwareComponentStatisticsCollector & System::get_read_statistics() const
+{
+  return read_statistics_;
+}
+
+const HardwareComponentStatisticsCollector & System::get_write_statistics() const
+{
+  return write_statistics_;
+}
+
 return_type System::read(const rclcpp::Time & time, const rclcpp::Duration & period)
 {
   if (lifecycleStateThatRequiresNoAction(impl_->get_lifecycle_state().id()))
@@ -310,7 +322,20 @@ return_type System::read(const rclcpp::Time & time, const rclcpp::Duration & per
     {
       error();
     }
-    last_read_cycle_time_ = time;
+    if (trigger_result.successful)
+    {
+      if (trigger_result.execution_time.has_value())
+      {
+        read_statistics_.execution_time->AddMeasurement(
+          static_cast<double>(trigger_result.execution_time.value().count()) / 1.e3);
+      }
+      if (last_read_cycle_time_.get_clock_type() != RCL_CLOCK_UNINITIALIZED)
+      {
+        read_statistics_.periodicity->AddMeasurement(
+          1.0 / (time - last_read_cycle_time_).seconds());
+      }
+      last_read_cycle_time_ = time;
+    }
     return trigger_result.result;
   }
   return return_type::OK;
@@ -332,7 +357,20 @@ return_type System::write(const rclcpp::Time & time, const rclcpp::Duration & pe
     {
       error();
     }
-    last_write_cycle_time_ = time;
+    if (trigger_result.successful)
+    {
+      if (trigger_result.execution_time.has_value())
+      {
+        write_statistics_.execution_time->AddMeasurement(
+          static_cast<double>(trigger_result.execution_time.value().count()) / 1.e3);
+      }
+      if (last_write_cycle_time_.get_clock_type() != RCL_CLOCK_UNINITIALIZED)
+      {
+        write_statistics_.periodicity->AddMeasurement(
+          1.0 / (time - last_write_cycle_time_).seconds());
+      }
+      last_write_cycle_time_ = time;
+    }
     return trigger_result.result;
   }
   return return_type::OK;

--- a/hardware_interface_testing/test/test_components/test_actuator.cpp
+++ b/hardware_interface_testing/test/test_components/test_actuator.cpp
@@ -111,6 +111,11 @@ class TestActuator : public ActuatorInterface
 
   return_type read(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/) override
   {
+    if (get_hardware_info().is_async)
+    {
+      std::this_thread::sleep_for(
+        std::chrono::milliseconds(1000 / (3 * get_hardware_info().rw_rate)));
+    }
     // simulate error on read
     if (velocity_command_ == test_constants::READ_FAIL_VALUE)
     {
@@ -135,6 +140,11 @@ class TestActuator : public ActuatorInterface
 
   return_type write(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/) override
   {
+    if (get_hardware_info().is_async)
+    {
+      std::this_thread::sleep_for(
+        std::chrono::milliseconds(1000 / (6 * get_hardware_info().rw_rate)));
+    }
     // simulate error on write
     if (velocity_command_ == test_constants::WRITE_FAIL_VALUE)
     {

--- a/hardware_interface_testing/test/test_components/test_system.cpp
+++ b/hardware_interface_testing/test/test_components/test_system.cpp
@@ -100,6 +100,11 @@ class TestSystem : public SystemInterface
 
   return_type read(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/) override
   {
+    if (get_hardware_info().is_async)
+    {
+      std::this_thread::sleep_for(
+        std::chrono::milliseconds(1000 / (3 * get_hardware_info().rw_rate)));
+    }
     // simulate error on read
     if (velocity_command_[0] == test_constants::READ_FAIL_VALUE)
     {
@@ -124,6 +129,11 @@ class TestSystem : public SystemInterface
 
   return_type write(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/) override
   {
+    if (get_hardware_info().is_async)
+    {
+      std::this_thread::sleep_for(
+        std::chrono::milliseconds(1000 / (6 * get_hardware_info().rw_rate)));
+    }
     // simulate error on write
     if (velocity_command_[0] == test_constants::WRITE_FAIL_VALUE)
     {

--- a/ros2_control_test_assets/include/ros2_control_test_assets/descriptions.hpp
+++ b/ros2_control_test_assets/include/ros2_control_test_assets/descriptions.hpp
@@ -758,6 +758,55 @@ const auto hardware_resources_with_different_rw_rates =
   </ros2_control>
 )";
 
+const auto hardware_resources_with_different_rw_rates_with_async =
+  R"(
+  <ros2_control name="TestActuatorHardware" type="actuator" rw_rate="50" is_async="true">
+    <hardware>
+      <plugin>test_actuator</plugin>
+    </hardware>
+    <joint name="joint1">
+      <command_interface name="position"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+      <command_interface name="max_velocity" />
+    </joint>
+  </ros2_control>
+  <ros2_control name="TestSensorHardware" type="sensor" rw_rate="20" is_async="true">
+    <hardware>
+      <plugin>test_sensor</plugin>
+      <param name="example_param_write_for_sec">2</param>
+      <param name="example_param_read_for_sec">2</param>
+    </hardware>
+    <sensor name="sensor1">
+      <state_interface name="velocity"/>
+    </sensor>
+  </ros2_control>
+  <ros2_control name="TestSystemHardware" type="system" rw_rate="25" is_async="true">
+    <hardware>
+      <plugin>test_system</plugin>
+      <param name="example_param_write_for_sec">2</param>
+      <param name="example_param_read_for_sec">2</param>
+    </hardware>
+    <joint name="joint2">
+      <command_interface name="velocity"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+      <state_interface name="acceleration"/>
+      <command_interface name="max_acceleration" />
+    </joint>
+    <joint name="joint3">
+      <command_interface name="velocity"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+      <state_interface name="acceleration"/>
+    </joint>
+    <gpio name="configuration">
+      <command_interface name="max_tcp_jerk"/>
+      <state_interface name="max_tcp_jerk"/>
+    </gpio>
+  </ros2_control>
+)";
+
 const auto hardware_resources_with_negative_rw_rates =
   R"(
   <ros2_control name="TestActuatorHardware" type="actuator" rw_rate="-50">


### PR DESCRIPTION
This PR aims to add diagnostics to the hardware components regarding their periodicity and execution time.

This PR also publishes the periodicity of controller and HW components that run at different rate 

**Tested (https://github.com/ros-controls/ros2_control/pull/2005) on the real hardware and it seems to work as expected**

**The diagnostics should kinda look like the following screenshots (The following are only to look at the summary):**

![image](https://github.com/user-attachments/assets/4ebafaac-f750-4e0e-8870-6af8f7290023)
![image](https://github.com/user-attachments/assets/48dc0295-fd11-41dd-a096-2547fc5c1981)
![image](https://github.com/user-attachments/assets/1bc45057-55d3-40b6-a238-268f7e6d3fbf)
![image](https://github.com/user-attachments/assets/6ee5d786-84b3-4d02-a66a-9b5a30e58a1c)

![image](https://github.com/user-attachments/assets/37613a73-7047-4893-a3a2-be01fbbb0380)
![image](https://github.com/user-attachments/assets/a0d6e70f-9822-4dbb-8ded-92c1c3afda08)
![image](https://github.com/user-attachments/assets/a63e06b6-de5d-40c2-a011-ecfc32e3261e)
